### PR TITLE
fix: snake must not move in opposite direction

### DIFF
--- a/sucury.py
+++ b/sucury.py
@@ -230,16 +230,16 @@ while True:
 
           # Key pressed
         if event.type == pygame.KEYDOWN:
-            if event.key == pygame.K_DOWN:    # Down arrow:  move down
+            if event.key == pygame.K_DOWN and snake.ymov != -1:    # Down arrow:  move down
                 snake.ymov = 1
                 snake.xmov = 0
-            elif event.key == pygame.K_UP:    # Up arrow:    move up
+            elif event.key == pygame.K_UP and snake.ymov != 1:    # Up arrow:    move up
                 snake.ymov = -1
                 snake.xmov = 0
-            elif event.key == pygame.K_RIGHT: # Right arrow: move right
+            elif event.key == pygame.K_RIGHT and snake.xmov != -1: # Right arrow: move right
                 snake.ymov = 0
                 snake.xmov = 1
-            elif event.key == pygame.K_LEFT:  # Left arrow:  move left
+            elif event.key == pygame.K_LEFT and snake.xmov != 1:  # Left arrow:  move left
                 snake.ymov = 0
                 snake.xmov = -1
             elif event.key == pygame.K_q:     # Q         : quit game


### PR DESCRIPTION
For example, if a snake is looking up, it should not move down. So we should disconsider the event if the player presses the down arrow. The same is valid for the other directions.