### PR TITLE
fix: changes default window size to 650x650

### DIFF
--- a/sucury.py
+++ b/sucury.py
@@ -31,7 +31,7 @@ import sys
 ## Game customization.
 ##
 
-WIDTH, HEIGHT = 800, 800     # Game screen dimensions.
+WIDTH, HEIGHT = 650, 650     # Game screen dimensions.
 
 grid_size = 50               # Square grid size.
 


### PR DESCRIPTION
On non full HD monitors, the size 800x800 is too large. To accommodate those monitors, it was necessary to lower the default scale.

Closes #23  