### PR TITLE
feature: Includes `END` and `ESC` keys to quit behavior

### DIFF
--- a/sucury.py
+++ b/sucury.py
@@ -326,7 +326,7 @@ while True:
                     snake.change_direction(RIGHT)
                 elif event.key == pygame.K_LEFT or event.key == pygame.K_a:  # Left arrow or A:  move left
                     snake.change_direction(LEFT)
-                elif event.key == pygame.K_q:     # Q         : quit game
+                elif event.key in [pygame.K_q, pygame.K_ESCAPE, pygame.K_END]:     # Q | END | ESC         : quit game
                     pygame.quit()
                     sys.exit()
 

--- a/sucury.py
+++ b/sucury.py
@@ -97,7 +97,7 @@ def center_prompt(title, subtitle):
         if event.type == pygame.QUIT:
             pygame.quit()
             sys.exit()
-    if event.key == pygame.K_q:          # 'Q' quits game
+    if event.key in [ pygame.K_q, pygame.K_ESCAPE, pygame.K_END ]:          # 'Q' quits game
         pygame.quit()
         sys.exit()
 


### PR DESCRIPTION
Closes #107 

- Replicate the same behavior of pressing `q` (quitting the game while running) with the `ESC` and `END` keys